### PR TITLE
Mean normalization vector correction

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -1,4 +1,4 @@
-VGG_MEAN = [104, 117, 123]
+VGG_MEAN = [123, 117, 104]
 
 
 def create_yahoo_image_loader():


### PR DESCRIPTION
Hi, 

Just pointing out something I came across while I was reading the code. The image representation is converted from RGB to BGR, but the VGG_MEAN vector that contains the mean pixel value of dataset is in order of RGB.

For reference, the [original implementation](https://github.com/yahoo/open_nsfw/blob/master/classify_nsfw.py#L114) by Yahoo converts from RGB to BGR after mean normalization. 

However, the image loader here scales the mean after reordering the channel. So the R and B values were being subtracted by means of B and R respectively. This is a fix that corrects this behavior.